### PR TITLE
fix: bad helm_ls cmd

### DIFF
--- a/lua/lspconfig/server_configurations/helm_ls.lua
+++ b/lua/lspconfig/server_configurations/helm_ls.lua
@@ -1,7 +1,7 @@
 local util = require 'lspconfig.util'
 
 local bin_name = 'helm_ls'
-local cmd = { bin_name, "serve" }
+local cmd = { bin_name, 'serve' }
 
 if vim.fn.has 'win32' == 1 then
   cmd = { 'cmd.exe', '/C', unpack(cmd) }

--- a/lua/lspconfig/server_configurations/helm_ls.lua
+++ b/lua/lspconfig/server_configurations/helm_ls.lua
@@ -1,15 +1,15 @@
 local util = require 'lspconfig.util'
 
 local bin_name = 'helm_ls'
-local cmd = { bin_name }
+local cmd = { bin_name, "serve" }
 
 if vim.fn.has 'win32' == 1 then
-  cmd = { 'cmd.exe', '/C', bin_name }
+  cmd = { 'cmd.exe', '/C', unpack(cmd) }
 end
 
 return {
   default_config = {
-    cmd = { cmd, 'serve' },
+    cmd = cmd,
     filetypes = { 'helm' },
     root_dir = util.root_pattern 'Chart.yaml',
     single_file_support = true,


### PR DESCRIPTION
Loading helm files currently fails with this error:
```
Error executing lua callback: /usr/share/nvim/runtime/lua/vim/lsp.lua:239: cmd argument: expected string, got table
```

This is caused by `cmd` being set to `{ { 'helm_ls' }, 'serve' } }` instead of `{ 'helm_ls', 'serve' }`.